### PR TITLE
Fix play error from type cast issues

### DIFF
--- a/lib/soundpool.dart
+++ b/lib/soundpool.dart
@@ -65,9 +65,10 @@ class Soundpool {
   /// start
   Future<int> play(int soundId, {int repeat = 0}) async {
     assert(!_disposed, "Soundpool instance was already disposed");
-    return await _soundpoolId.future.then((poolId) => _channel.invokeMethod(
+    int poolId = await _soundpoolId.future;
+    return await _channel.invokeMethod(
             "play", {"poolId": poolId, "soundId": soundId, "repeat": repeat})
-        as int);
+        as int;
   }
 
   /// Sets volume for playing sound identified by [soundId] or [streamId]


### PR DESCRIPTION
@ukasz123 I noticed There was a type error being thrown by the `play` method. I have no idea why Dart didn't like it, but this PR fixes it. Here's the Error:
```
E/flutter (25179): [ERROR:flutter/shell/common/shell.cc(181)] Dart Error: Unhandled exception:
E/flutter (25179): type 'Future<dynamic>' is not a subtype of type 'int' in type cast
E/flutter (25179): #0      Object._as (dart:core/runtime/libobject_patch.dart:74:25)
E/flutter (25179): #1      Soundpool.play.<anonymous closure> (package:soundpool/soundpool.dart:63:109)
E/flutter (25179): #2      _RootZone.runUnary (dart:async/zone.dart:1379:54)
E/flutter (25179): #3      _FutureListener.handleValue (dart:async/future_impl.dart:129:18)
E/flutter (25179): #4      Future._propagateToListeners.handleValueCallback (dart:async/future_impl.dart:642:45)
E/flutter (25179): #5      Future._propagateToListeners (dart:async/future_impl.dart:671:32)
E/flutter (25179): #6      Future._addListener.<anonymous closure> (dart:async/future_impl.dart:351:9)
E/flutter (25179): #7      _microtaskLoop (dart:async/schedule_microtask.dart:41:21)
E/flutter (25179): #8      _startMicrotaskLoop (dart:async/schedule_microtask.dart:50:5)
```
