### PR TITLE
Fix for Flutter 2.10 compilation error due to new Kotlin minimum version

### DIFF
--- a/soundpool/android/build.gradle
+++ b/soundpool/android/build.gradle
@@ -2,7 +2,7 @@ group 'pl.ukaszapps.soundpool'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.6.10'
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
This pull request updates the minimum Kotlin version required by the project in order to solve compilation problems with Flutter 2.10.

More details can be found here:
https://docs.flutter.dev/release/breaking-changes/kotlin-version
