### PR TITLE
Remove AudioSession management

### DIFF
--- a/soundpool/ios/Classes/SwiftSoundpoolPlugin.swift
+++ b/soundpool/ios/Classes/SwiftSoundpoolPlugin.swift
@@ -20,9 +20,6 @@ public class SwiftSoundpoolPlugin: NSObject, FlutterPlugin {
             // TODO create distinction between different types of audio playback
             let attributes = call.arguments as! NSDictionary
             
-            // It will not init AudioSession, instead it should be opened using another package like "audio_session" (https://pub.dev/packages/audio_session)
-            //initAudioSession(attributes)
-            
             let maxStreams = attributes["maxStreams"] as! Int
             let enableRate = (attributes["ios_enableRate"] as? Bool) ?? true
             let wrapper = SoundpoolWrapper(maxStreams, enableRate)
@@ -56,56 +53,6 @@ public class SwiftSoundpoolPlugin: NSObject, FlutterPlugin {
                 break
             }
             wrapper.handle(call, result: result)
-        }
-    }
-    
-    private func initAudioSession(_ attributes: NSDictionary) {
-        if #available(iOS 10.0, *) {
-            guard let categoryAttr = attributes["ios_avSessionCategory"] as? String else {
-                return
-            }
-            let modeAttr = attributes["ios_avSessionMode"] as! String
-            
-            let category: AVAudioSession.Category
-            switch categoryAttr {
-            case "ambient":
-                category = .ambient
-            case "playback":
-                category = .playback
-            case "playAndRecord":
-                category = .playAndRecord
-            case "multiRoute":
-                category = .multiRoute
-            default:
-                category = .soloAmbient
-                
-            }
-            let mode: AVAudioSession.Mode
-            switch modeAttr {
-            case "moviePlayback":
-                mode = .moviePlayback
-            case "videoRecording":
-                mode = .videoRecording
-            case "voiceChat":
-                mode = .voiceChat
-            case "gameChat":
-                mode = .gameChat
-            case "videoChat":
-                mode = .videoChat
-            case "spokenAudio":
-                mode = .spokenAudio
-            case "measurement":
-                mode = .measurement
-            default:
-                mode = .default
-            }
-            do {
-                try AVAudioSession.sharedInstance().setCategory(category, mode: mode)
-                print("Audio session updated: category = '\(category)', mode = '\(mode)'.")
-            } catch (let e) {
-                //do nothing
-                print("Error while trying to set audio category: '\(e)'")
-            }
         }
     }
     

--- a/soundpool/ios/Classes/SwiftSoundpoolPlugin.swift
+++ b/soundpool/ios/Classes/SwiftSoundpoolPlugin.swift
@@ -20,7 +20,8 @@ public class SwiftSoundpoolPlugin: NSObject, FlutterPlugin {
             // TODO create distinction between different types of audio playback
             let attributes = call.arguments as! NSDictionary
             
-            initAudioSession(attributes)
+            // It will not init AudioSession, instead it should be opened using another package like "audio_session" (https://pub.dev/packages/audio_session)
+            //initAudioSession(attributes)
             
             let maxStreams = attributes["maxStreams"] as! Int
             let enableRate = (attributes["ios_enableRate"] as? Bool) ?? true

--- a/soundpool/lib/src/platforms/ios.dart
+++ b/soundpool/lib/src/platforms/ios.dart
@@ -6,47 +6,11 @@ class SoundpoolOptionsIos {
   /// Default value: `true`
   final bool enableRate;
 
-  /// Audio Session category for shared [AVAudioSession](https://developer.apple.com/documentation/avfaudio/avaudiosession)
-  final AudioSessionCategory? audioSessionCategory;
-
-  /// Audio Session mode for shared [AVAudioSession](https://developer.apple.com/documentation/avfaudio/avaudiosession)
-  final AudioSessionMode audioSessionMode;
-
   const SoundpoolOptionsIos({
     this.enableRate = true,
-    this.audioSessionCategory,
-    this.audioSessionMode = AudioSessionMode.normal,
   });
 
   Map<String, dynamic> toOptionsMap() => {
         'enableRate': enableRate,
-        'avSessionCategory': audioSessionCategory?.toString().split('.').last,
-        'avSessionMode': audioSessionMode.toString().split('.').last,
       };
-}
-
-/// See:
-/// - [Audio Session Categories and Modes](https://developer.apple.com/library/archive/documentation/Audio/Conceptual/AudioSessionProgrammingGuide/AudioSessionCategoriesandModes/AudioSessionCategoriesandModes.html#//apple_ref/doc/uid/TP40007875-CH10)
-/// - [Audio Session Programming Guide](https://developer.apple.com/library/archive/documentation/Audio/Conceptual/AudioSessionProgrammingGuide/AudioSessionBasics/AudioSessionBasics.html#//apple_ref/doc/uid/TP40007875-CH3-SW1)
-enum AudioSessionCategory {
-  ambient,
-  soloAmbient,
-  playback,
-  playAndRecord,
-  multiRoute,
-}
-
-/// See:
-/// - [Audio Session Categories and Modes](https://developer.apple.com/library/archive/documentation/Audio/Conceptual/AudioSessionProgrammingGuide/AudioSessionCategoriesandModes/AudioSessionCategoriesandModes.html#//apple_ref/doc/uid/TP40007875-CH10)
-/// - [Audio Session Programming Guide](https://developer.apple.com/library/archive/documentation/Audio/Conceptual/AudioSessionProgrammingGuide/AudioSessionBasics/AudioSessionBasics.html#//apple_ref/doc/uid/TP40007875-CH3-SW1)
-enum AudioSessionMode {
-  /// 'Default' mode
-  normal,
-  moviePlayback,
-  videoRecording,
-  voiceChat,
-  gameChat,
-  videoChat,
-  spokenAudio,
-  measurement,
 }


### PR DESCRIPTION
Since AudioSession is shared across the whole app, it may be used by other plugins too, so the right way to manage this is to use a specific plugin for this purpose (like https://pub.dev/packages/audio_session for instance). That way the AudioSession will be managed only by one plugin and it will avoid any conflicts because other plugins want to manage it too.

You can read more about this on this comment of another similar package
https://github.com/Canardoux/flutter_sound/issues/855#issuecomment-1066059995