### PR TITLE
Change return type of dispose to Future<void>

### DIFF
--- a/soundpool/CHANGELOG.md
+++ b/soundpool/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.3.0+1
+* Change return type of dispose to Future<void> so it can be awaited
 ## 2.3.0
 * Update for **Flutter 2.10**
 ## 2.2.0

--- a/soundpool/lib/soundpool.dart
+++ b/soundpool/lib/soundpool.dart
@@ -306,8 +306,8 @@ class Soundpool {
   /// Disposes soundpool
   ///
   /// The Soundpool instance is not usable anymore
-  void dispose() {
-    _soundpoolId.future
+  Future<void> dispose() async {
+    await _soundpoolId.future
         .then((poolId) => _platformInstance.dispose(poolId), onError: (_) {});
     _disposed = true;
   }
@@ -315,7 +315,7 @@ class Soundpool {
   StreamType get streamType => _streamType;
 
   /// Connects to native Soundpool instance
-  _connect() async {
+  Future<void> _connect() async {
     final int id = await _platformInstance.init(
         _streamType.index, _maxStreams, _platformOptions);
     if (id >= 0) {

--- a/soundpool/pubspec.yaml
+++ b/soundpool/pubspec.yaml
@@ -1,6 +1,6 @@
 name: soundpool
 description: A Flutter Sound Pool for playing short audio files. Sound tracks are cached in memory and played directly from cache.
-version: 2.3.0
+version: 2.3.0+1
 homepage: https://github.com/ukasz123/soundpool/tree/master/soundpool
 
 environment:


### PR DESCRIPTION
Change dispose return type to `Future<void>` so the dispose call of _platformInstance can be awaited.