### PR TITLE
Remove deprecated `registerWith` method for plugin registration. (can't build android app with flitter 3.29.0)

### DIFF
--- a/soundpool/android/src/main/kotlin/pl/ukaszapps/soundpool/SoundpoolPlugin.kt
+++ b/soundpool/android/src/main/kotlin/pl/ukaszapps/soundpool/SoundpoolPlugin.kt
@@ -14,7 +14,6 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
-import io.flutter.plugin.common.PluginRegistry.Registrar
 import java.io.File
 import java.io.FileOutputStream
 import java.net.URI
@@ -27,13 +26,6 @@ internal val uiThreadHandler: Handler = Handler(Looper.getMainLooper())
 
 class SoundpoolPlugin : MethodCallHandler, FlutterPlugin {
     companion object {
-        @Suppress("unused")
-        @JvmStatic
-        fun registerWith(registrar: Registrar) {
-            var pool = SoundpoolPlugin()
-            pool.onRegister(registrar.context(), registrar.messenger())
-        }
-
         private const val CHANNEL_NAME = "pl.ukaszapps/soundpool"
     }
 


### PR DESCRIPTION
The `registerWith` method using `Registrar` has been removed as it is no longer needed with the current Flutter plugin API. 
If not deleted this method will happen Android build error when Flutter version 3.29.0.